### PR TITLE
Add block range filters when getting transfers by contract or wallet

### DIFF
--- a/src/lib/Api/api.ts
+++ b/src/lib/Api/api.ts
@@ -44,6 +44,8 @@ export type GetTransfersByBlockHashOptions = {
 
 export type GetNftTransfersByWallet = {
   walletAddress: string;
+  fromBlock?: number;
+  toBlock?: number;
   cursor?: string;
 };
 
@@ -61,6 +63,8 @@ export type GetNftTransfersByContractAndToken = {
 
 export type GetNftTransfersByContractAddress = {
   contractAddress: string;
+  fromBlock?: number;
+  toBlock?: number;
   cursor?: string;
 };
 export type GetNftOwnersByContractAddress = {
@@ -258,9 +262,30 @@ export default class Api {
         location: Logger.location.SDK_GET_TRANSFERS_BY_WALLET,
       });
     }
+    if (opts.fromBlock != null && !isValidPositiveNumber(opts.fromBlock)) {
+      log.throwArgumentError(Logger.message.invalid_block_number, 'fromBlock', opts.fromBlock, {
+        location: Logger.location.SDK_GET_TRANSFERS_BY_WALLET,
+      });
+    }
+    if (opts.toBlock != null && !isValidPositiveNumber(opts.toBlock)) {
+      log.throwArgumentError(Logger.message.invalid_block_number, 'toBlock', opts.toBlock, {
+        location: Logger.location.SDK_GET_TRANSFERS_BY_WALLET,
+      });
+    }
+    if (opts.fromBlock != null && opts.toBlock != null && opts.fromBlock > opts.toBlock) {
+      log.throwError(Logger.message.invalid_block_range, Logger.code.INVALID_ARGUMENT, {
+        location: Logger.location.SDK_GET_TRANSFERS_BY_WALLET,
+        fromBlock: opts.fromBlock,
+        toBlock: opts.toBlock,
+      });
+    }
 
     const apiUrl = `${this.apiPath}/accounts/${opts.walletAddress}/assets/transfers`;
-    const { data } = await this.httpClient.get(apiUrl, { cursor: opts.cursor });
+    const { data } = await this.httpClient.get(apiUrl, {
+      fromBlock: opts.fromBlock,
+      toBlock: opts.toBlock,
+      cursor: opts.cursor,
+    });
     return data;
   }
 
@@ -325,10 +350,32 @@ export default class Api {
         location: Logger.location.SDK_GET_TRANSFERS_BY_CONTRACT,
       });
     }
+    if (opts.fromBlock != null && !isValidPositiveNumber(opts.fromBlock)) {
+      log.throwArgumentError(Logger.message.invalid_block_number, 'fromBlock', opts.fromBlock, {
+        location: Logger.location.SDK_GET_TRANSFERS_BY_CONTRACT,
+      });
+    }
+    if (opts.toBlock != null && !isValidPositiveNumber(opts.toBlock)) {
+      log.throwArgumentError(Logger.message.invalid_block_number, 'toBlock', opts.toBlock, {
+        location: Logger.location.SDK_GET_TRANSFERS_BY_CONTRACT,
+      });
+    }
+    if (opts.fromBlock != null && opts.toBlock != null && opts.fromBlock > opts.toBlock) {
+      log.throwError(Logger.message.invalid_block_range, Logger.code.INVALID_ARGUMENT, {
+        location: Logger.location.SDK_GET_TRANSFERS_BY_CONTRACT,
+        fromBlock: opts.fromBlock,
+        toBlock: opts.toBlock,
+      });
+    }
 
     const apiUrl = `${this.apiPath}/nfts/${opts.contractAddress}/transfers`;
-    const { contractAddress, cursor } = opts;
-    const { data } = await this.httpClient.get(apiUrl, { contractAddress, cursor });
+    const { contractAddress, fromBlock, toBlock, cursor } = opts;
+    const { data } = await this.httpClient.get(apiUrl, {
+      contractAddress,
+      fromBlock,
+      toBlock,
+      cursor,
+    });
     return data;
   }
 

--- a/src/lib/Logger/index.ts
+++ b/src/lib/Logger/index.ts
@@ -210,6 +210,7 @@ export enum ErrorMessage {
   unsupported_provider = 'unsupported provider',
   invalid_block_number = 'Invalid block number.',
   invalid_block_hash = 'Invalid block hash.',
+  invalid_block_range = 'fromBlock must be less than or equal to toBlock',
 }
 
 export class Logger {

--- a/src/services/nft-api.ts
+++ b/src/services/nft-api.ts
@@ -574,6 +574,10 @@ export interface Operations {
         walletAddress: string;
       };
       query: {
+        /** The minimum block number to get transfers from */
+        fromBlock?: number;
+        /** The maximum block number to get transfers from */
+        toBlock?: number;
         /** The cursor returned in the previous response (to query the next page) */
         cursor?: string;
       };
@@ -628,6 +632,10 @@ export interface Operations {
         tokenAddress: string;
       };
       query: {
+        /** The minimum block number to get transfers from */
+        fromBlock?: number;
+        /** The maximum block number to get transfers from */
+        toBlock?: number;
         /** The cursor returned in the previous response (to query the next page) */
         cursor?: string;
       };

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -265,6 +265,27 @@ describe('Api', () => {
       );
     });
 
+    it('should validate fromBlock', async () => {
+      await expect(() =>
+        api.getNftsTransfersByWallet({ walletAddress: CONTRACT_ADDRESS, fromBlock: -1 }),
+      ).rejects.toThrow(
+        `Invalid block number. (location="[SDK.getNftTransfersByWallet]", argument="fromBlock", value=-1, code=INVALID_ARGUMENT, version=${version})`,
+      );
+    });
+    it('should validate toBlock', async () => {
+      await expect(() =>
+        api.getNftsTransfersByWallet({ walletAddress: CONTRACT_ADDRESS, toBlock: -1 }),
+      ).rejects.toThrow(
+        `Invalid block number. (location="[SDK.getNftTransfersByWallet]", argument="toBlock", value=-1, code=INVALID_ARGUMENT, version=${version})`,
+      );
+    });
+    it('should validate fromBlock <= toBlock', async () => {
+      await expect(() =>
+        api.getNftsTransfersByWallet({ walletAddress: CONTRACT_ADDRESS, fromBlock: 2, toBlock: 1 }),
+      ).rejects.toThrow(
+        `fromBlock must be less than or equal to toBlock (location="[SDK.getNftTransfersByWallet]", fromBlock=2, toBlock=1, code=INVALID_ARGUMENT, version=${version})`,
+      );
+    });
     it('should return transfers', async () => {
       HttpServiceMock.mockResolvedValueOnce(
         transferByBlockHashNumberMock as AxiosResponse<any, any>,
@@ -321,6 +342,31 @@ describe('Api', () => {
       );
     });
 
+    it('should validate fromBlock', async () => {
+      await expect(() =>
+        api.getTransfersByContractAddress({ contractAddress: CONTRACT_ADDRESS, fromBlock: -1 }),
+      ).rejects.toThrow(
+        `Invalid block number. (location="[SDK.getTransfersByContractAddress]", argument="fromBlock", value=-1, code=INVALID_ARGUMENT, version=${version})`,
+      );
+    });
+    it('should validate toBlock', async () => {
+      await expect(() =>
+        api.getTransfersByContractAddress({ contractAddress: CONTRACT_ADDRESS, toBlock: -1 }),
+      ).rejects.toThrow(
+        `Invalid block number. (location="[SDK.getTransfersByContractAddress]", argument="toBlock", value=-1, code=INVALID_ARGUMENT, version=${version})`,
+      );
+    });
+    it('should validate fromBlock <= toBlock', async () => {
+      await expect(() =>
+        api.getTransfersByContractAddress({
+          contractAddress: CONTRACT_ADDRESS,
+          fromBlock: 2,
+          toBlock: 1,
+        }),
+      ).rejects.toThrow(
+        `fromBlock must be less than or equal to toBlock (location="[SDK.getTransfersByContractAddress]", fromBlock=2, toBlock=1, code=INVALID_ARGUMENT, version=${version})`,
+      );
+    });
     it('should return transfers', async () => {
       HttpServiceMock.mockResolvedValueOnce(
         transferByBlockHashNumberMock as AxiosResponse<any, any>,

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -290,7 +290,11 @@ describe('Api', () => {
       HttpServiceMock.mockResolvedValueOnce(
         transferByBlockHashNumberMock as AxiosResponse<any, any>,
       );
-      await api.getNftsTransfersByWallet({ walletAddress: CONTRACT_ADDRESS });
+      await api.getNftsTransfersByWallet({
+        walletAddress: CONTRACT_ADDRESS,
+        fromBlock: 1,
+        toBlock: 2,
+      });
       expect(HttpServiceMock).toHaveBeenCalledTimes(1);
     });
   });
@@ -371,7 +375,11 @@ describe('Api', () => {
       HttpServiceMock.mockResolvedValueOnce(
         transferByBlockHashNumberMock as AxiosResponse<any, any>,
       );
-      await api.getTransfersByContractAddress({ contractAddress: CONTRACT_ADDRESS });
+      await api.getTransfersByContractAddress({
+        contractAddress: CONTRACT_ADDRESS,
+        fromBlock: 1,
+        toBlock: 2,
+      });
       expect(HttpServiceMock).toHaveBeenCalledTimes(1);
     });
   });


### PR DESCRIPTION
Adds query parameters `fromBlock` and `toBlock` when getting transfers by contract or wallet