### PR TITLE
Add block range validation when getting transfers by contract

### DIFF
--- a/src/lib/Api/api.ts
+++ b/src/lib/Api/api.ts
@@ -360,12 +360,21 @@ export default class Api {
         location: Logger.location.SDK_GET_TRANSFERS_BY_CONTRACT,
       });
     }
-    if (opts.fromBlock != null && opts.toBlock != null && opts.fromBlock > opts.toBlock) {
-      log.throwError(Logger.message.invalid_block_range, Logger.code.INVALID_ARGUMENT, {
-        location: Logger.location.SDK_GET_TRANSFERS_BY_CONTRACT,
-        fromBlock: opts.fromBlock,
-        toBlock: opts.toBlock,
-      });
+    if (opts.fromBlock != null && opts.toBlock != null) {
+      if (opts.fromBlock > opts.toBlock) {
+        log.throwError(Logger.message.invalid_block_range, Logger.code.INVALID_ARGUMENT, {
+          location: Logger.location.SDK_GET_TRANSFERS_BY_CONTRACT,
+          fromBlock: opts.fromBlock,
+          toBlock: opts.toBlock,
+        });
+      }
+      if (opts.toBlock - opts.fromBlock > 1000000) {
+        log.throwError(Logger.message.block_range_too_large, Logger.code.INVALID_ARGUMENT, {
+          location: Logger.location.SDK_GET_TRANSFERS_BY_CONTRACT,
+          fromBlock: opts.fromBlock,
+          toBlock: opts.toBlock,
+        });
+      }
     }
 
     const apiUrl = `${this.apiPath}/nfts/${opts.contractAddress}/transfers`;

--- a/src/lib/Logger/index.ts
+++ b/src/lib/Logger/index.ts
@@ -211,6 +211,7 @@ export enum ErrorMessage {
   invalid_block_number = 'Invalid block number.',
   invalid_block_hash = 'Invalid block hash.',
   invalid_block_range = 'fromBlock must be less than or equal to toBlock',
+  block_range_too_large = 'Block range must be less than or equal to 1,000,000 blocks',
 }
 
 export class Logger {

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -371,6 +371,17 @@ describe('Api', () => {
         `fromBlock must be less than or equal to toBlock (location="[SDK.getTransfersByContractAddress]", fromBlock=2, toBlock=1, code=INVALID_ARGUMENT, version=${version})`,
       );
     });
+    it('should validate block range <= 1,000,000', async () => {
+      await expect(() =>
+        api.getTransfersByContractAddress({
+          contractAddress: CONTRACT_ADDRESS,
+          fromBlock: 1,
+          toBlock: 2000000,
+        }),
+      ).rejects.toThrow(
+        `Block range must be less than or equal to 1,000,000 blocks (location=\"[SDK.getTransfersByContractAddress]\", fromBlock=1, toBlock=2000000, code=INVALID_ARGUMENT, version=${version})`,
+      );
+    });
     it('should return transfers', async () => {
       HttpServiceMock.mockResolvedValueOnce(
         transferByBlockHashNumberMock as AxiosResponse<any, any>,


### PR DESCRIPTION
Validates that the block range is less than 1,000,000 blocks when getting transfers by contract address.